### PR TITLE
Add sublime text 3 paths to check list

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -8,6 +8,8 @@ if [[ $('uname') == 'Linux' ]]; then
         "/usr/bin/sublime_text"
         "/usr/local/bin/sublime_text"
         "/usr/bin/subl"
+        "/opt/sublime_text_3/sublime_text"
+        "/usr/bin/subl3"
     )
     for _sublime_path in $_sublime_linux_paths; do
         if [[ -a $_sublime_path ]]; then


### PR DESCRIPTION
Sublime text 3 has a slightly different install location, as well as a different binary executable. This is tested and working on arch linux, I believe other distros have a similar installation location.
